### PR TITLE
Set up Travis to run the python tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install numpy pystan pandas matplotlib
+  - pip install -U -r python/requirements.txt
 
 script:
   - cd python && python setup.py develop test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+
+install:
+  - pip install --upgrade pip
+  - pip install numpy pystan pandas matplotlib
+
+script:
+  - cd python && python setup.py develop test

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,5 @@
+Cython>=0.22
+pystan>=2.14
+numpy>=1.10.0
+pandas>=0.18.1
+matplotlib>=2.0.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -109,7 +109,7 @@ setup(
     ],
     install_requires=[
         'matplotlib',
-        'numpy',
+        'numpy>=1.10.0',
         'pandas>=0.18.1',
         'pystan>=2.14',
     ],

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,7 @@ from setuptools import setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 from setuptools.command.test import test as test_command
+from setuptools.dist import Distribution
 
 
 PLATFORM = 'unix'
@@ -94,6 +95,11 @@ class TestCommand(test_command):
             sys.modules.update(old_modules)
             working_set.__init__()
 
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name."""
+    def has_ext_modules(foo):
+        return True
+
 setup(
     name='fbprophet',
     version='0.1.post1',
@@ -120,6 +126,7 @@ setup(
         'develop': DevelopCommand,
         'test': TestCommand,
     },
+    distclass=BinaryDistribution,
     test_suite='fbprophet.tests.test_prophet',
     long_description="""
 Implements a procedure for forecasting time series data based on an additive model where non-linear trends are fit with yearly and weekly seasonality, plus holidays.  It works best with daily periodicity data with at least one year of historical data.  Prophet is robust to missing data, shifts in the trend, and large outliers.


### PR DESCRIPTION
Hey

We would really like to start using fbprophet from iPython and Cloud Datalab notebooks. At the moment installing the Python version requires a build environment (gcc) to compile the pystan models though. We could avoid that by building and releasing wheel packages to PyPI instead. 

I am proposing to use [Travis](https://travis-ci.org) to continuously build and test the Python fbprophet package. On top of that, we could easily [automate uploading wheels to PyPI](https://docs.travis-ci.com/user/deployment/pypi/) for every release. If this sounds like a good idea I'm happy to provide an additional PR for that.